### PR TITLE
Fix className properCase generation

### DIFF
--- a/src/python-output.ts
+++ b/src/python-output.ts
@@ -113,7 +113,7 @@ class PythonOutput {
                     ) {
                         listTypes.add(findType(item, this.datetime));
                     } else {
-                        const className = key.charAt(0).toUpperCase() + key.slice(1);
+                        const className = properCase(key);
                         listTypes.add(`${className}`);
                         for (const item of data[key]) {
                             this.findObjs(item, agg, key);
@@ -171,7 +171,10 @@ class PythonOutput {
 }
 
 const properCase = (word: string): string => {
-    return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
+    return (
+        word.charAt(0).toUpperCase() +
+        word.substr(1).replace(/([-_][a-z])/g, (group) => group.toUpperCase().replace('-', '').replace('_', ''))
+    );
 };
 
 const findType = (data: boolean | number | String, datetime: boolean): string => {


### PR DESCRIPTION
This properly CamelCases class names, whereas previously they would be converted from `class_name` to `Class_name`, now they become `ClassName`, for both types and custom classes.

Before:
<img width="502" alt="Screenshot 2020-04-17 at 17 29 46" src="https://user-images.githubusercontent.com/1148665/79621737-b3b93100-80d1-11ea-8b31-4aa890f70eed.png">

After:
<img width="490" alt="Screenshot 2020-04-17 at 17 34 22" src="https://user-images.githubusercontent.com/1148665/79621742-b9af1200-80d1-11ea-8541-125145d6cc90.png">
