### PR TITLE
Deduplicate generated classes

### DIFF
--- a/src/python-output.ts
+++ b/src/python-output.ts
@@ -66,8 +66,9 @@ class PythonOutput {
     update = () => {
         if (this.data != '') {
             this.elem.innerHTML = '';
-            const objs = [];
+            const objs = new Map();
             const data = JSON.parse(this.data);
+
             this.findObjs(data, objs);
             let output = '';
 
@@ -85,8 +86,8 @@ class PythonOutput {
                 output += importStrings.dataclass;
                 output += '<br><br>';
             }
-            for (const obj of objs) {
-                output += this.createClass(obj);
+            for (const [name, obj] of Object.entries(objs)) {
+                output += this.createClass(name, obj);
                 output += '<br><br>';
             }
             this.elem.innerHTML = output;
@@ -95,9 +96,11 @@ class PythonOutput {
         }
     };
 
-    findObjs = (data: object, agg: object[], parent: string = 'GeneratedClass'): void => {
+    findObjs = (data: object, agg: Map<string, object>, parent: string = 'GeneratedClass'): void => {
         let obj = {};
-        obj[parent] = {};
+        if (agg.has(parent)) {
+            obj = agg.get(parent)
+        }
         for (const key in data) {
             if (data[key] !== null && data[key] instanceof Array) {
                 if (this.imports.indexOf('list') == -1) {
@@ -121,32 +124,30 @@ class PythonOutput {
                     }
                 }
                 if (listTypes.size < 1) {
-                    obj[parent][key] = `List`;
+                    obj[key] = `List`;
                 } else if (listTypes.size > 1) {
                     if (this.imports.indexOf('union') == -1) {
                         this.imports.push('union');
                     }
                     let typeArr = Array.from(listTypes.values());
-                    obj[parent][key] = `List[Union[${typeArr.join(', ')}]]`;
+                    obj[key] = `List[Union[${typeArr.join(', ')}]]`;
                 } else {
-                    obj[parent][key] = `List[${listTypes.values().next().value}]`;
+                    obj[key] = `List[${listTypes.values().next().value}]`;
                 }
             } else if (data[key] !== null && typeof data[key] == 'object') {
-                obj[parent][key] = properCase(key);
+                obj[key] = properCase(key);
                 this.findObjs(data[key], agg, key);
             } else {
-                obj[parent][key] = findType(data[key], this.datetime);
+                obj[key] = findType(data[key], this.datetime);
             }
         }
 
-        agg.push(obj);
+        agg.set(parent, obj);
     };
 
-    createClass = (data: object): string => {
-        const name = Object.keys(data)[0];
-        const obj = data[name];
+    createClass = (name: string, data: object): string => {
         let types = '';
-        for (const [key, value] of Object.entries(obj)) {
+        for (const [key, value] of Object.entries(data)) {
             let keyName = key;
             if (this.snakeCase) {
                 keyName = key

--- a/src/python-output.ts
+++ b/src/python-output.ts
@@ -66,7 +66,7 @@ class PythonOutput {
     update = () => {
         if (this.data != '') {
             this.elem.innerHTML = '';
-            const objs = new Map();
+            const objs = {};
             const data = JSON.parse(this.data);
 
             this.findObjs(data, objs);
@@ -96,10 +96,10 @@ class PythonOutput {
         }
     };
 
-    findObjs = (data: object, agg: Map<string, object>, parent: string = 'GeneratedClass'): void => {
+    findObjs = (data: object, agg: object, parent: string = 'GeneratedClass'): void => {
         let obj = {};
-        if (agg.has(parent)) {
-            obj = agg.get(parent)
+        if (agg.hasOwnProperty(parent)) {
+            obj = agg[parent]
         }
         for (const key in data) {
             if (data[key] !== null && data[key] instanceof Array) {
@@ -142,10 +142,10 @@ class PythonOutput {
             }
         }
 
-        agg.set(parent, obj);
+        agg[parent] = obj
     };
 
-    createClass = (name: string, data: object): string => {
+    createClass = (name: string, data: any): string => {
         let types = '';
         for (const [key, value] of Object.entries(data)) {
             let keyName = key;


### PR DESCRIPTION
I wanted to dedupe the output, but still maintain the order, as I believe that's helpful, but found that it wouldn't actually iterate through the map when compiled. This may be an issue with microbundle not handling newer syntax, or some other thing.

I then on a whim tried replacing the `Map` with `{}` and it turned out to work just as well, keeping the order as far as I could tell, so that may be the way to go.

I used output from https://pokeapi.co to test, e.g. https://pokeapi.co/api/v2/pokemon/ditto/

Before:
<img width="301" alt="Screenshot 2020-04-17 at 17 25 02" src="https://user-images.githubusercontent.com/1148665/79621385-6ee0ca80-80d0-11ea-9e8b-9c721ecc801c.png">

After:
<img width="286" alt="Screenshot 2020-04-17 at 17 25 17" src="https://user-images.githubusercontent.com/1148665/79621390-77390580-80d0-11ea-8537-3105306667d3.png">
